### PR TITLE
Use Alpine for Base Docker Image and Update to Python 3.12

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
 
       - name: Install pre-commit and pip-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     args:
       - --in-place
       - --aggressive
+      - --max-line-length=110
 - repo: https://github.com/pycqa/flake8
   rev: 7.3.0
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine AS base
+FROM python:3.12-alpine AS base
 
 # Install base system requirements
 RUN apk add --no-cache ffmpeg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-alpine AS base
-RUN apt update -y && apt install -y ffmpeg
+
+# Install base system requirements
+RUN apk add --no-cache ffmpeg postgresql-dev
+
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.11-alpine AS base
 
-# Install base system requirements
-RUN apk add --no-cache ffmpeg postgresql-dev
-
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.11-alpine AS base
 
+# Install base system requirements
+RUN apk add --no-cache ffmpeg
+
 WORKDIR /code
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm AS base
+FROM python:3.11-alpine AS base
 RUN apt update -y && apt install -y ffmpeg
 WORKDIR /code
 COPY requirements.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 archivessnake==0.10.1
     # via -r requirements.in
-attrs==25.3.0
+attrs==25.4.0
     # via archivessnake
 aws-assume-role-lib==2.10.0
     # via -r requirements.in
@@ -8,23 +8,23 @@ bagit==1.9.0
     # via -r requirements.in
 boltons==25.0.0
     # via archivessnake
-boto3==1.40.42
+boto3==1.40.53
     # via
     #   -r requirements.in
     #   aws-assume-role-lib
-botocore==1.40.42
+botocore==1.40.53
     # via
     #   boto3
     #   s3transfer
-certifi==2025.8.3
+certifi==2025.10.5
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
 ffmpeg-python==0.2.0
     # via -r requirements.in
 future==1.0.0
     # via ffmpeg-python
-idna==3.10
+idna==3.11
     # via requests
 jmespath==1.0.1
     # via

--- a/src/package.py
+++ b/src/package.py
@@ -193,7 +193,8 @@ class Packager(object):
 
     def uri_from_refid(self, refid):
         """Uses the find_by_id endpoint in AS to return the URI of an archival object."""
-        find_by_refid_url = f"repositories/{self.as_repo}/find_by_id/archival_objects?ref_id[]={refid}"
+        find_by_refid_url = f"repositories / {
+            self.as_repo} / find_by_id / archival_objects?ref_id[] = {refid}"
         resp = self.as_client.get(find_by_refid_url)
         resp.raise_for_status()
         results = resp.json()
@@ -354,7 +355,9 @@ class Packager(object):
         client = self.get_client_with_role('sns', self.role_arn)
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{self.format} package {self.refid} successfully packaged',
+            Message=f'{
+                self.format} package {
+                self.refid} successfully packaged',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',
@@ -385,7 +388,12 @@ class Packager(object):
         tb = ''.join(traceback.format_exception(exception)[:-1])
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{getattr(self, "format", "unknown format")} package {self.refid} failed packaging',
+            Message=f'{
+                getattr(
+                    self,
+                    "format",
+                    "unknown format")} package {
+                self.refid} failed packaging',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',
@@ -457,7 +465,8 @@ if __name__ == '__main__':
         'AWS_DESTINATION_BUCKET_AUDIO_ACCESS')
     destination_bucket_poster = os.environ.get('AWS_DESTINATION_BUCKET_POSTER')
     sns_topic = os.environ.get('AWS_SNS_TOPIC')
-    ssm_parameter_path = f"/{os.environ.get('ENV')}/{os.environ.get('APP_CONFIG_PATH')}"
+    ssm_parameter_path = f"/ {os.environ.get('ENV')
+                              } / {os.environ.get('APP_CONFIG_PATH')}"
 
     Packager(
         region,

--- a/src/package.py
+++ b/src/package.py
@@ -193,8 +193,8 @@ class Packager(object):
 
     def uri_from_refid(self, refid):
         """Uses the find_by_id endpoint in AS to return the URI of an archival object."""
-        find_by_refid_url = f"repositories / {
-            self.as_repo} / find_by_id / archival_objects?ref_id[] = {refid}"
+        find_by_refid_url = f"repositories/{
+            self.as_repo}/find_by_id/archival_objects?ref_id[]={refid}"
         resp = self.as_client.get(find_by_refid_url)
         resp.raise_for_status()
         results = resp.json()

--- a/src/package.py
+++ b/src/package.py
@@ -193,8 +193,7 @@ class Packager(object):
 
     def uri_from_refid(self, refid):
         """Uses the find_by_id endpoint in AS to return the URI of an archival object."""
-        find_by_refid_url = f"repositories/{
-            self.as_repo}/find_by_id/archival_objects?ref_id[]={refid}"
+        find_by_refid_url = f"repositories/{self.as_repo}/find_by_id/archival_objects?ref_id[]={refid}"
         resp = self.as_client.get(find_by_refid_url)
         resp.raise_for_status()
         results = resp.json()
@@ -355,9 +354,7 @@ class Packager(object):
         client = self.get_client_with_role('sns', self.role_arn)
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{
-                self.format} package {
-                self.refid} successfully packaged',
+            Message=f'{self.format} package {self.refid} successfully packaged',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',
@@ -388,12 +385,7 @@ class Packager(object):
         tb = ''.join(traceback.format_exception(exception)[:-1])
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'{
-                getattr(
-                    self,
-                    "format",
-                    "unknown format")} package {
-                self.refid} failed packaging',
+            Message=f'{getattr(self, "format", "unknown format")} package {self.refid} failed packaging',
             MessageAttributes={
                 'format': {
                     'DataType': 'String',
@@ -465,8 +457,7 @@ if __name__ == '__main__':
         'AWS_DESTINATION_BUCKET_AUDIO_ACCESS')
     destination_bucket_poster = os.environ.get('AWS_DESTINATION_BUCKET_POSTER')
     sns_topic = os.environ.get('AWS_SNS_TOPIC')
-    ssm_parameter_path = f"/ {os.environ.get('ENV')
-                              } / {os.environ.get('APP_CONFIG_PATH')}"
+    ssm_parameter_path = f"/{os.environ.get('ENV')}/{os.environ.get('APP_CONFIG_PATH')}"
 
     Packager(
         region,

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py311, linting
+envlist = py312, linting
 skipsdist = True
 
 [testenv]
 skip_install = True
 
-[testenv:py311]
+[testenv:py312]
 allowlist_externals = docker
 passenv =
   USER

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
   USER
 commands =
 	docker build -t digitized_av_packaging_test --target test .
-  docker run digitized_av_packaging_test bash -c "coverage run -m pytest -s && coverage report -m"
+  docker run digitized_av_packaging_test sh -c "coverage run -m pytest -s && coverage report -m"
 
 [testenv:linting]
 allowlist_externals = pre-commit


### PR DESCRIPTION
Converts Docker base image to Alpine, requiring the use of sh instead of bash.

Also updates from Python 3.11 to 3.12

This update caused issues with autopep8's default 79 character line length, so I extended it to 110. I think this may be related to a change in [how python 3.12 handles f-strings](https://docs.python.org/3/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings).